### PR TITLE
Move Config Settings to new position in the ACP

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -82,8 +82,8 @@ class listener implements EventSubscriberInterface
 		// Load language file
 		$this->user->add_lang_ext('phpbb/googleanalytics', 'googleanalytics_acp');
 
-		// Add a config to the settings mode, after override_user_style
-		if ($event['mode'] == 'settings' && isset($event['display_vars']['vars']['override_user_style']))
+		// Add a config to the settings mode, after board_timezone
+		if ($event['mode'] == 'settings' && isset($event['display_vars']['vars']['board_timezone']))
 		{
 			// Store display_vars event in a local variable
 			$display_vars = $event['display_vars'];
@@ -98,8 +98,8 @@ class listener implements EventSubscriberInterface
 				),
 			);
 
-			// Add the new config vars after override_user_style in the display_vars config array
-			$insert_after = array('after' => 'override_user_style');
+			// Add the new config vars after board_timezone in the display_vars config array
+			$insert_after = array('after' => 'board_timezone');
 			$display_vars['vars'] = phpbb_insert_config_array($display_vars['vars'], $ga_config_vars, $insert_after);
 
 			// Update the display_vars event with the new array

--- a/tests/event/listener_test.php
+++ b/tests/event/listener_test.php
@@ -106,13 +106,13 @@ class event_listener_test extends \phpbb_test_case
 		return array(
 			array( // expected config and mode
 				'settings',
-				array('vars' => array('override_user_style' => array())),
-				array('override_user_style', 'googleanalytics_id'),
+				array('vars' => array('board_timezone' => array())),
+				array('board_timezone', 'googleanalytics_id'),
 			),
 			array( // unexpected mode
 				'foobar',
-				array('vars' => array('override_user_style' => array())),
-				array('override_user_style'),
+				array('vars' => array('board_timezone' => array())),
+				array('board_timezone'),
 			),
 			array( // unexpected config
 				'settings',

--- a/tests/functional/google_analytics_test.php
+++ b/tests/functional/google_analytics_test.php
@@ -47,11 +47,11 @@ class google_analytics_test extends \phpbb_functional_test_case
 		// Load ACP board settings page
 		$crawler = self::request('GET', 'adm/index.php?i=acp_board&mode=settings&sid=' . $this->sid);
 
-		// Test that GA settings field is found in the correct position (after OVERRIDE_STYLE)
+		// Test that GA settings field is found in the correct position (after SYSTEM_TIMEZONE)
 		$nodes = $crawler->filter('#acp_board > fieldset > dl > dt > label')->extract(array('_text'));
 		foreach ($nodes as $key => $config_name)
 		{
-			if (strpos($config_name, $this->lang('OVERRIDE_STYLE')) !== 0)
+			if (strpos($config_name, $this->lang('SYSTEM_TIMEZONE')) !== 0)
 			{
 				continue;
 			}


### PR DESCRIPTION
Recent changes to the layout of the ACP Board Settings requires we move the GA Config option to a new position.
