### PR TITLE
Update overall_header_stylesheets_after.html

### DIFF
--- a/styles/all/template/event/overall_header_stylesheets_after.html
+++ b/styles/all/template/event/overall_header_stylesheets_after.html
@@ -6,6 +6,7 @@
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
 	ga('create', '{GOOGLEANALYTICS_ID}', 'auto');
+	<!-- EVENT phpbb_googleanalytics_alter_ga_requirements -->
 	ga('send', 'pageview');
 </script>
 <!-- ENDIF -->


### PR DESCRIPTION
Add the option to set extra options for google analytics after create, so other extensions can add tracking options (Like adding the ability to track advertisements). See here for a example: https://support.google.com/analytics/answer/2444872?hl=en&utm_id=ad
