### PR TITLE
Migrate from older analytics.js to newer gtag.js

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -67,6 +67,7 @@ class listener implements EventSubscriberInterface
 	{
 		$this->template->assign_vars(array(
 			'GOOGLEANALYTICS_ID'		=> $this->config['googleanalytics_id'],
+			'GOOGLEANALYTICS_TAG'		=> $this->config['googleanalytics_tag'],
 			'GOOGLEANALYTICS_USER_ID'	=> $this->user->data['user_id'],
 			'S_ANONYMIZE_IP'			=> $this->config['ga_anonymize_ip'],
 		));
@@ -103,6 +104,17 @@ class listener implements EventSubscriberInterface
 					'lang'		=> 'ACP_GA_ANONYMIZE_IP',
 					'validate'	=> 'bool',
 					'type'		=> 'radio:yes_no',
+					'explain'	=> true,
+				),
+				'googleanalytics_tag' => array(
+					'lang'		=> 'ACP_GOOGLEANALYTICS_TAG',
+					'validate'	=> 'int',
+					'type'		=> 'select',
+					'function'	=> 'build_select',
+					'params'	=> array(array(
+						0	=> 'ACP_GA_ANALYTICS_TAG',
+						1	=> 'ACP_GA_GTAGS_TAG',
+					), '{CONFIG_VALUE}'),
 					'explain'	=> true,
 				),
 			);

--- a/language/en/googleanalytics_acp.php
+++ b/language/en/googleanalytics_acp.php
@@ -40,12 +40,12 @@ if (empty($lang) || !is_array($lang))
 $lang = array_merge($lang, array(
 	'ACP_GOOGLEANALYTICS'				=> 'Google Analytics',
 	'ACP_GOOGLEANALYTICS_ID'			=> 'Google Analytics ID',
-	'ACP_GOOGLEANALYTICS_ID_EXPLAIN'	=> 'Enter your Google Analytics ID code, e.g.: <samp>UA-0000000-00</samp>.<br /><br />Google Analytics can track your registered users across multiple devices and sessions, for a more accurate user count in your reports. To enable this enhanced functionality User ID tracking must be configured in your Google Analytics account. <a href="https://support.google.com/analytics/answer/3123666">Click for more information</a>.',
+	'ACP_GOOGLEANALYTICS_ID_EXPLAIN'	=> 'Enter your Google Analytics ID code, e.g.: <samp>UA-0000000-00</samp>.<br /><br />Google Analytics can track your registered users across multiple devices and sessions, for a more accurate user count in your reports. To enable this enhanced functionality User ID tracking must be configured in your Google Analytics account. <a href="https://support.google.com/analytics/answer/3123666">Click for more information <i class="icon fa-external-link fa-fw" aria-hidden="true"></i></a>.',
 	'ACP_GOOGLEANALYTICS_ID_INVALID'	=> '“%s” is not a valid Google Analytics ID code.<br />It should be in the form “UA-0000000-00”.',
 	'ACP_GA_ANONYMIZE_IP'				=> 'Turn on IP Anonymization',
 	'ACP_GA_ANONYMIZE_IP_EXPLAIN'		=> 'Enable this option if you want the data collected by Google Analytics to be compliant with the EU‘s General Data Protection Regulation (GDPR). Note that enabling this option may slightly reduce the accuracy of geographic reporting.',
 	'ACP_GOOGLEANALYTICS_TAG'			=> 'Google Analytics Script Tag',
-	'ACP_GOOGLEANALYTICS_TAG_EXPLAIN'	=> 'Choose your preferred Google Analytics code snippet. Global site tag (gtag.js) is the current snippet recommended by Google. Google Analytics tag (analytics.js) is the legacy code snippet. <a href="https://developers.google.com/analytics/devguides/collection/gtagjs/migration">Click for more information</a>.',
+	'ACP_GOOGLEANALYTICS_TAG_EXPLAIN'	=> 'Choose your preferred Google Analytics code snippet. Global site tag (gtag.js) is the current snippet recommended by Google. Google Analytics tag (analytics.js) is the legacy code snippet. <a href="https://developers.google.com/analytics/devguides/collection/gtagjs/migration">Click for more information <i class="icon fa-external-link fa-fw" aria-hidden="true"></i></a>.',
 	'ACP_GA_ANALYTICS_TAG'				=> 'Google Analytics Tag (analytics.js)',
 	'ACP_GA_GTAGS_TAG'					=> 'Global Site Tag (gtag.js)',
 ));

--- a/language/en/googleanalytics_acp.php
+++ b/language/en/googleanalytics_acp.php
@@ -44,4 +44,8 @@ $lang = array_merge($lang, array(
 	'ACP_GOOGLEANALYTICS_ID_INVALID'	=> '“%s” is not a valid Google Analytics ID code.<br />It should be in the form “UA-0000000-00”.',
 	'ACP_GA_ANONYMIZE_IP'				=> 'Turn on IP Anonymization',
 	'ACP_GA_ANONYMIZE_IP_EXPLAIN'		=> 'Enable this option if you want the data collected by Google Analytics to be compliant with the EU‘s General Data Protection Regulation (GDPR). Note that enabling this option may slightly reduce the accuracy of geographic reporting.',
+	'ACP_GOOGLEANALYTICS_TAG'			=> 'Google Analytics Script Tag',
+	'ACP_GOOGLEANALYTICS_TAG_EXPLAIN'	=> 'Choose your preferred Google Analytics code snippet. Global site tag (gtag.js) is the current snippet recommended by Google. Google Analytics tag (analytics.js) is the legacy code snippet. <a href="https://developers.google.com/analytics/devguides/collection/gtagjs/migration">Click for more information</a>.',
+	'ACP_GA_ANALYTICS_TAG'				=> 'Google Analytics Tag (analytics.js)',
+	'ACP_GA_GTAGS_TAG'					=> 'Global Site Tag (gtag.js)',
 ));

--- a/migrations/v10x/m3_tag_option.php
+++ b/migrations/v10x/m3_tag_option.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ *
+ * Google Analytics extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2019 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\googleanalytics\migrations\v10x;
+
+/**
+ * Migration stage 3: Add Google Analytics tag config option
+ */
+class m3_tag_option extends \phpbb\db\migration\migration
+{
+	/**
+	 * {@inheritdoc}
+	 */
+	public static function depends_on()
+	{
+		return array('\phpbb\googleanalytics\migrations\v10x\m1_initial_data');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function effectively_installed()
+	{
+		return $this->config->offsetExists('googleanalytics_tag');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 *
+	 * Note setting this option: If there is an existing Google Analytics ID set,
+	 * we will set this to 0 so we continue using the legacy GA code snippet. If
+	 * no Analytics ID is set, lets set this to 1 so that we promote using the new
+	 * Global Tag snippet in new installations.
+	 */
+	public function update_data()
+	{
+		return array(
+			array('config.add', array('googleanalytics_tag', (int) empty($this->config['googleanalytics_id']))),
+		);
+	}
+}

--- a/styles/all/template/event/overall_header_stylesheets_after.html
+++ b/styles/all/template/event/overall_header_stylesheets_after.html
@@ -1,16 +1,32 @@
 {% if GOOGLEANALYTICS_ID %}
-	<!-- https://developers.google.com/analytics/devguides/collection/gtagjs/migration -->
-	<!-- Global site tag (gtag.js) - Google Analytics -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLEANALYTICS_ID }}"></script>
-	<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
+	{# 0 = Legacy (analytics.js) - Google Analytics #}
+	{# 1 = Global site tag (gtag.js) - Google Analytics #}
+	{% if GOOGLEANALYTICS_TAG == 1 %}
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLEANALYTICS_ID }}"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
 
-		gtag('config', '{{ GOOGLEANALYTICS_ID }}', {
-			{% EVENT phpbb_googleanalytics_gtag_options %}
-			{% if S_REGISTERED_USER %}'user_id': '{{ GOOGLEANALYTICS_USER_ID }}',{% endif %}
-			{% if S_ANONYMIZE_IP %}'anonymize_ip': true,{% endif %}
-		});
-	</script>
+			gtag('config', '{{ GOOGLEANALYTICS_ID }}', {
+				{% EVENT phpbb_googleanalytics_gtag_options %}
+				{% if S_REGISTERED_USER %}'user_id': '{{ GOOGLEANALYTICS_USER_ID }}',{% endif %}
+				{% if S_ANONYMIZE_IP %}'anonymize_ip': true,{% endif %}
+			});
+		</script>
+	{% else %}
+		<script>
+			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+			})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+			ga('create', '{{ GOOGLEANALYTICS_ID }}', 'auto');
+			{% if S_REGISTERED_USER %}ga('set', 'userId', {{ GOOGLEANALYTICS_USER_ID }});{% endif %}
+			{% if S_ANONYMIZE_IP %}ga('set', 'anonymizeIp', true);{% endif %}
+			{% EVENT phpbb_googleanalytics_alter_ga_requirements -%}
+			ga('send', 'pageview');
+		</script>
+	{% endif %}
 {% endif %}

--- a/styles/all/template/event/overall_header_stylesheets_after.html
+++ b/styles/all/template/event/overall_header_stylesheets_after.html
@@ -1,18 +1,16 @@
 {% if GOOGLEANALYTICS_ID %}
-<script>
-	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+	<!-- https://developers.google.com/analytics/devguides/collection/gtagjs/migration -->
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLEANALYTICS_ID }}"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
 
-	ga('create', '{{ GOOGLEANALYTICS_ID }}', 'auto');
-	{% if S_REGISTERED_USER -%}
-	ga('set', 'userId', {{ GOOGLEANALYTICS_USER_ID }});
-	{% endif -%}
-	{% if S_ANONYMIZE_IP -%}
-	ga('set', 'anonymizeIp', true);
-	{% endif -%}
-	{% EVENT phpbb_googleanalytics_alter_ga_requirements -%}
-	ga('send', 'pageview');
-</script>
+		gtag('config', '{{ GOOGLEANALYTICS_ID }}', {
+			{% EVENT phpbb_googleanalytics_gtag_options %}
+			{% if S_REGISTERED_USER %}'user_id': '{{ GOOGLEANALYTICS_USER_ID }}',{% endif %}
+			{% if S_ANONYMIZE_IP %}'anonymize_ip': true,{% endif %}
+		});
+	</script>
 {% endif %}

--- a/styles/all/template/event/overall_header_stylesheets_after.html
+++ b/styles/all/template/event/overall_header_stylesheets_after.html
@@ -10,9 +10,9 @@
 			gtag('js', new Date());
 
 			gtag('config', '{{ GOOGLEANALYTICS_ID }}', {
-				{% EVENT phpbb_googleanalytics_gtag_options %}
-				{% if S_REGISTERED_USER %}'user_id': '{{ GOOGLEANALYTICS_USER_ID }}',{% endif %}
-				{% if S_ANONYMIZE_IP %}'anonymize_ip': true,{% endif %}
+				{%- EVENT phpbb_googleanalytics_gtag_options -%}
+				{%- if S_REGISTERED_USER %}'user_id': '{{ GOOGLEANALYTICS_USER_ID }}',{% endif -%}
+				{%- if S_ANONYMIZE_IP %}'anonymize_ip': true,{% endif -%}
 			});
 		</script>
 	{% else %}

--- a/tests/event/listener_test.php
+++ b/tests/event/listener_test.php
@@ -93,6 +93,7 @@ class listener_test extends \phpbb_test_case
 			->method('assign_vars')
 			->with(array(
 				'GOOGLEANALYTICS_ID'		=> $this->config['googleanalytics_id'],
+				'GOOGLEANALYTICS_TAG'		=> $this->config['googleanalytics_tag'],
 				'GOOGLEANALYTICS_USER_ID'	=> $this->user->data['user_id'],
 				'S_ANONYMIZE_IP'			=> $this->config['ga_anonymize_ip'],
 			));
@@ -113,7 +114,7 @@ class listener_test extends \phpbb_test_case
 			array( // expected config and mode
 				'settings',
 				array('vars' => array('warnings_expire_days' => array())),
-				array('warnings_expire_days', 'legend_googleanalytics', 'googleanalytics_id', 'ga_anonymize_ip'),
+				array('warnings_expire_days', 'legend_googleanalytics', 'googleanalytics_id', 'ga_anonymize_ip', 'googleanalytics_tag'),
 			),
 			array( // unexpected mode
 				'foobar',

--- a/tests/functional/google_analytics_test.php
+++ b/tests/functional/google_analytics_test.php
@@ -82,6 +82,6 @@ class google_analytics_test extends \phpbb_functional_test_case
 	public function test_google_analytics_code()
 	{
 		$crawler = self::request('GET', 'index.php');
-		$this->assertContains($this->sample_ga_code, $crawler->filter('head > script')->text());
+		$this->assertContains($this->sample_ga_code, $crawler->filter('head > script')->eq(1)->text());
 	}
 }


### PR DESCRIPTION
Looks like Google switched to a new tracking code at some point. While older analytics.js code is still supported, we may want to upgrade to this new one (when I go into my Analytics control panel, this is the code snippet Google now recommends using).

This update will not be fully backwards compatible with any extensions that may have been using its template event to inject custom analytics code.

So this should probably lead to a major new version update, in which case we may want to consider also dropping support for 3.1.x (and removing any deprecated 3.1.x code).

~~I'm also not sure if we should just use this new code...or have an ACP option to use (and thus maintain) both the older analytics.js or this newer gtag.js code snippet.~~
Went ahead and added the option for users to switch between legacy analytics.js or use the new Google Tag gtag.js

https://developers.google.com/analytics/devguides/collection/gtagjs/migration